### PR TITLE
Change license to LGPL-3.0-or-later

### DIFF
--- a/COPYING.LESSER
+++ b/COPYING.LESSER
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Geometrical Counter-Poise Correction
 
-[![GPL-3.0-or-later](https://img.shields.io/github/license/grimme-lab/gcp)](LICENSE)
+[![LGPL-3.0-or-later](https://img.shields.io/github/license/grimme-lab/gcp)](LICENSE)
 [![Latest Version](https://img.shields.io/github/v/release/grimme-lab/gcp)](https://github.com/grimme-lab/gcp/releases/latest)
 [![CI](https://github.com/grimme-lab/gcp/workflows/CI/badge.svg)](https://github.com/grimme-lab/gcp/actions)
 [![DOI](https://img.shields.io/badge/DOI-10.1063%2F1.3700154-blue)](https://doi.org/10.1063/1.3700154)
@@ -135,16 +135,16 @@ For the “3c” methods see:
 ## License
 
 This project is free software: you can redistribute it and/or modify it under
-the terms of the GNU General Public License as published by
+the terms of the Lesser GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
 This project is distributed in the hope that it will be useful,
 but without any warranty; without even the implied warranty of
 merchantability or fitness for a particular purpose.  See the
-GNU General Public License for more details.
+Lesser GNU General Public License for more details.
 
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in this project by you, as defined in the
-GNU General Public license, shall be licensed as above, without any
+Lesser GNU General Public license, shall be licensed as above, without any
 additional terms or conditions.

--- a/app/main.f90
+++ b/app/main.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 program main

--- a/app/meson.build
+++ b/app/meson.build
@@ -1,17 +1,17 @@
 # This file is part of mctc-gcp.
-# SPDX-Identifier: GPL-3.0-or-later
+# SPDX-Identifier: LGPL-3.0-or-later
 #
 # mctc-gcp is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by
+# the terms of the Lesser GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # mctc-gcp is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# Lesser GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the Lesser GNU General Public License
 # along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 gcp_exe = executable(

--- a/config/meson.build
+++ b/config/meson.build
@@ -1,17 +1,17 @@
 # This file is part of mctc-gcp.
-# SPDX-Identifier: GPL-3.0-or-later
+# SPDX-Identifier: LGPL-3.0-or-later
 #
 # mctc-gcp is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by
+# the terms of the Lesser GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # mctc-gcp is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# Lesser GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the Lesser GNU General Public License
 # along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 os = host_machine.system()

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,6 +1,6 @@
 name = "mctc-gcp"
-version = "2.1.2"
-license = "GPL-3.0-or-later"
+version = "2.3.1"
+license = "LGPL-3.0-or-later"
 maintainer = ["@grimme-lab"]
 author = ["Stefan Grimme", "J. Gerit Brandenburg", "Holger Kruse"]
 copyright = "2012-2021 Grimme group"

--- a/meson.build
+++ b/meson.build
@@ -1,24 +1,24 @@
 # This file is part of mctc-gcp.
-# SPDX-Identifier: GPL-3.0-or-later
+# SPDX-Identifier: LGPL-3.0-or-later
 #
 # mctc-gcp is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by
+# the terms of the Lesser GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # mctc-gcp is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# Lesser GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the Lesser GNU General Public License
 # along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 project(
   'mctc-gcp',
   'fortran',
-  version: '2.3.0',
-  license: 'GPL-3.0-or-later',
+  version: '2.3.1',
+  license: 'LGPL-3.0-or-later',
   meson_version: '>=0.53',
   default_options: [
     'buildtype=debugoptimized',
@@ -61,6 +61,7 @@ subdir('old')
 # Package the license files
 gcp_lic = files(
   'COPYING',
+  'COPYING.LESSER',
 )
 
 if install

--- a/old/meson.build
+++ b/old/meson.build
@@ -1,17 +1,17 @@
 # This file is part of mctc-gcp.
-# SPDX-Identifier: GPL-3.0-or-later
+# SPDX-Identifier: LGPL-3.0-or-later
 #
 # mctc-gcp is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by
+# the terms of the Lesser GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # mctc-gcp is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# Lesser GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the Lesser GNU General Public License
 # along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 gcp_exe = executable(

--- a/src/gcp.f90
+++ b/src/gcp.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 module gcp

--- a/src/gcp_precision.f90
+++ b/src/gcp_precision.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 module gcp_precision

--- a/src/gcp_strings.f90
+++ b/src/gcp_strings.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 module gcp_strings

--- a/src/gcp_version.f90
+++ b/src/gcp_version.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 !> Versioning information on this library.
@@ -24,10 +24,10 @@ module gcp_version
 
 
    !> String representation of the mctc-gcp version
-   character(len=*), parameter :: gcp_version_string = "2.3.0"
+   character(len=*), parameter :: gcp_version_string = "2.3.1"
 
    !> Numeric representation of the mctc-gcp version
-   integer, parameter :: gcp_version_compact(3) = [2, 3, 0]
+   integer, parameter :: gcp_version_compact(3) = [2, 3, 1]
 
 
 contains

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,16 +1,17 @@
-# This file is part of mctc-rmsd.
+# This file is part of mctc-gcp.
+# SPDX-Identifier: LGPL-3.0-or-later
 #
 # mctc-rmsd is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by
+# the terms of the Lesser GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # mctc-rmsd is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# Lesser GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the Lesser GNU General Public License
 # along with mctc-rmsd.  If not, see <https://www.gnu.org/licenses/>.
 
 srcs += files(

--- a/test/main.f90
+++ b/test/main.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 !> Driver for unit testing

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,17 +1,17 @@
 # This file is part of mctc-gcp.
-# SPDX-Identifier: GPL-3.0-or-later
+# SPDX-Identifier: LGPL-3.0-or-later
 #
 # mctc-gcp is free software: you can redistribute it and/or modify it under
-# the terms of the GNU General Public License as published by
+# the terms of the Lesser GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # mctc-gcp is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# Lesser GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License
+# You should have received a copy of the Lesser GNU General Public License
 # along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 # Create mstore as subproject for testing

--- a/test/test_gcp_3c_methods.f90
+++ b/test/test_gcp_3c_methods.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 module test_gcp_3c_methods

--- a/test/test_gcp_dft_methods.f90
+++ b/test/test_gcp_dft_methods.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 module test_gcp_dft_methods

--- a/test/test_gcp_gradient.f90
+++ b/test/test_gcp_gradient.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 module test_gcp_gradient

--- a/test/test_gcp_hf_methods.f90
+++ b/test/test_gcp_hf_methods.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 module test_gcp_hf_methods

--- a/test/test_gcp_pbc.f90
+++ b/test/test_gcp_pbc.f90
@@ -1,17 +1,17 @@
 ! This file is part of mctc-gcp.
-! SPDX-Identifier: GPL-3.0-or-later
+! SPDX-Identifier: LGPL-3.0-or-later
 !
 ! mctc-gcp is free software: you can redistribute it and/or modify it under
-! the terms of the GNU General Public License as published by
+! the terms of the Lesser GNU General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
 ! (at your option) any later version.
 !
 ! mctc-gcp is distributed in the hope that it will be useful,
 ! but WITHOUT ANY WARRANTY; without even the implied warranty of
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-! GNU General Public License for more details.
+! Lesser GNU General Public License for more details.
 !
-! You should have received a copy of the GNU General Public License
+! You should have received a copy of the Lesser GNU General Public License
 ! along with mctc-gcp.  If not, see <https://www.gnu.org/licenses/>.
 
 module test_gcp_pbc


### PR DESCRIPTION
We want to update the licensing terms from GPL-3.0-or-later to LGPL-3.0-or-later to allow third-party projects to link against the GCP library. Currently non GPL compatible projects are restricted to using the command line interface.

@hokru @gbrandenburg Please confirm you are okay with this license change.

cc @gasevic