### PR TITLE
Add DLLExports for MSVC

### DIFF
--- a/src/gcp.f90
+++ b/src/gcp.f90
@@ -19,6 +19,7 @@ module gcp
 contains
 !subroutine for interfacing with orca/turbomole/crystal
 subroutine gcp_call(n,xyz,lat,iz,gcp_e,gcp_g,gcp_glat,dograd,dohess,pbc,method,echo,parfile)
+   !DEC$ ATTRIBUTES DLLEXPORT :: gcp_call
 implicit none
 integer n   !number of atoms
 real*8 xyz(3,n) !xyzcoordinates
@@ -3160,6 +3161,7 @@ end
 !* and g to file <gradient>                            *
 !*******************************************************
 subroutine wregrad_tm(maxat,nat,xyz,iat,ifrez,edisp,gin,echo)
+   !DEC$ ATTRIBUTES DLLEXPORT :: wregrad_tm
 implicit none
 integer nat,iat(nat),maxat
 integer ifrez(nat)

--- a/src/gcp.f90
+++ b/src/gcp.f90
@@ -840,6 +840,7 @@ end subroutine sgcp
 !* print timings *
 !*****************
 subroutine prtim(io,tt,is,string)
+   !DEC$ ATTRIBUTES DLLEXPORT :: prtim
 integer io
 real*8 tt,t,sec
 integer day,hour,min
@@ -2652,6 +2653,7 @@ endif
 end subroutine g3s3s
 
 subroutine done(aa,io)
+    !DEC$ ATTRIBUTES DLLEXPORT :: done
 ! normal program termination
 implicit none
 integer io
@@ -2668,6 +2670,7 @@ end subroutine done
 !* directly with the coordinates.                           *
 !************************************************************
 subroutine tmolrd(maxat,xyz,iat,ifrez,nat,infile,echo)
+   !DEC$ ATTRIBUTES DLLEXPORT :: tmolrd
 implicit none
 integer maxat
 character*2 cc,ff
@@ -2849,6 +2852,7 @@ end subroutine
 
 
 subroutine help(h)
+   !DEC$ ATTRIBUTES DLLEXPORT :: help
 implicit none
 logical h
 
@@ -3563,6 +3567,7 @@ end
 !c    rdatomnumbervasp
 !c    reads the number of atoms from vasp file POSCAR
 subroutine rdatomnumbervasp(infile,n,echo)
+   !DEC$ ATTRIBUTES DLLEXPORT :: rdatomnumbervasp
 use gcp_strings
 implicit none
 !c input
@@ -3613,6 +3618,7 @@ end subroutine rdatomnumbervasp
 !c    read geometry from vasp file POSCAR
 !c    reads fixed coordinates (selective dynamics)
 subroutine rdcoordvasp(xyz,lat,iat,nat,infile,echo)
+   !DEC$ ATTRIBUTES DLLEXPORT :: rdcoordvasp
 use gcp_strings
 implicit none
 !input

--- a/src/gcp_strings.f90
+++ b/src/gcp_strings.f90
@@ -374,6 +374,7 @@ end function uppercase
 !**********************************************************************
 
 function lowercase(str) result(lcstr)
+   !DEC$ ATTRIBUTES DLLEXPORT :: lowercase
 
 ! convert string to lower case
 

--- a/src/gcp_strings.f90
+++ b/src/gcp_strings.f90
@@ -64,6 +64,7 @@ contains
 !**********************************************************************
 
 subroutine parse(str,delims,args,nargs)
+   !DEC$ ATTRIBUTES DLLEXPORT :: parse
 
 ! Parses the string 'str' into arguments args(1), ..., args(nargs) based on
 ! the delimiters contained in the string 'delims'. Preceding a delimiter in

--- a/src/gcp_version.f90
+++ b/src/gcp_version.f90
@@ -35,6 +35,7 @@ contains
 
 !> Getter function to retrieve mctc-gcp version
 subroutine get_gcp_version(major, minor, patch, string)
+   !DEC$ ATTRIBUTES DLLEXPORT :: get_gcp_version
 
    !> Major version number of the mctc-gcp version
    integer, intent(out), optional :: major


### PR DESCRIPTION
Without DLLExports, the build doesn't produce mctc-gcp.lib, which seems to be used by both the old and new commandline app. I split this into two commit with functions/subroutines needed to get the old and new apps to build. 