### PR TITLE
Increase test threshold

### DIFF
--- a/test/test_gcp_dft_methods.f90
+++ b/test/test_gcp_dft_methods.f90
@@ -25,7 +25,7 @@ module test_gcp_dft_methods
 
    public :: collect_gcp_dft_methods
 
-   real(wp), parameter :: thr = 100*epsilon(1.0_wp)
+   real(wp), parameter :: thr = 1000*epsilon(1.0_wp)
 
 
 contains


### PR DESCRIPTION
### Increase of test threshold

On `macos-14` on M3 Pro chip on my personal laptop, using `gcc-14.2.0.1`, `dft/minis` fails due to a too large difference in test results:

```
stdout:
** WARNING ** -> element mg has no virtual orbitals (no contribution)!
 Threshold size:    2.2204460492503131E-014
 error not located
 Method: dft/minis
  0.15921613343019420       0.15921613343027519        8.0990769646405170E-014
  0.15921613343019420     
 Threshold size:    2.2204460492503131E-014
 error not located
 Method: dft/minix
  0.10873902337093701       0.10873902337093687        1.3877787807814457E-016
 Threshold size:    2.2204460492503131E-014
 error not located
 Method: dft/sv
   4.2061458290263490E-002   4.2061458290263622E-002   1.3183898417423734E-016
 Threshold size:    2.2204460492503131E-014
 error not located
 Method: dft/def2-sv(p)
   3.6732928803961895E-002   3.6732928803962006E-002   1.1102230246251565E-016
 Threshold size:    2.2204460492503131E-014
 error not located
```

I'd say 10e-14 is still in the range of acceptable and might have very much underlying reasons, which is why I'd just increase the threshold. Effectively, it would be (on my machine) at: `2.2204460492503131E-013`
The same behavior is observed in the formula tests of https://github.com/grimme-lab/homebrew-qc, specifically under:
https://github.com/grimme-lab/homebrew-qc/actions/runs/11914547724/job/33210586002

In the unit tests, this is not the case, which puzzles me a bit...
